### PR TITLE
Add scrollbar to target apogee area

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,27 @@ body {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 15px;
     margin: 15px 0;
+    max-height: 400px;
+    overflow-y: auto;
+    padding-right: 10px;
+}
+
+.controls::-webkit-scrollbar {
+    width: 8px;
+}
+
+.controls::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+}
+
+.controls::-webkit-scrollbar-thumb {
+    background: rgba(0, 255, 255, 0.3);
+    border-radius: 4px;
+}
+
+.controls::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 255, 255, 0.5);
 }
 
 .control-group {

--- a/index.html
+++ b/index.html
@@ -82,32 +82,35 @@ body {
     min-height: 300px;
 }
 
-.controls {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 15px;
-    margin: 15px 0;
+.controls-container {
     max-height: 400px;
     overflow-y: auto;
     padding-right: 10px;
+    margin: 15px 0;
 }
 
-.controls::-webkit-scrollbar {
+.controls-container::-webkit-scrollbar {
     width: 8px;
 }
 
-.controls::-webkit-scrollbar-track {
+.controls-container::-webkit-scrollbar-track {
     background: rgba(0, 0, 0, 0.2);
     border-radius: 4px;
 }
 
-.controls::-webkit-scrollbar-thumb {
+.controls-container::-webkit-scrollbar-thumb {
     background: rgba(0, 255, 255, 0.3);
     border-radius: 4px;
 }
 
-.controls::-webkit-scrollbar-thumb:hover {
+.controls-container::-webkit-scrollbar-thumb:hover {
     background: rgba(0, 255, 255, 0.5);
+}
+
+.controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
 }
 
 .control-group {
@@ -357,40 +360,42 @@ const time = getTime();
 // Your flight logic here...
 }"></textarea>
     
-    <div class="controls">
-        <div class="control-group">
-            <label>Target Apogee (ft)</label>
-            <input type="number" id="maxAlt" value="3280" min="330" max="32800">
-        </div>
-        <div class="control-group">
-            <label>Max Velocity (ft/s)</label>
-            <input type="number" id="maxVel" value="656" min="164" max="1640">
-        </div>
-        <div class="control-group">
-            <label>Parachute System</label>
-            <select id="chuteSystem">
-                <option value="dual">Dual Deploy (Drogue + Main)</option>
-                <option value="single">Single Deploy (Main Only)</option>
-            </select>
-        </div>
-        <div class="control-group" id="mainDeployGroup">
-            <label>Main Deploy Altitude (ft)</label>
-            <input type="number" id="mainDeployAlt" value="800" min="100" max="2000">
-        </div>
-        <div class="control-group">
-            <label>Use Acceleration</label>
-            <select id="useAccel">
-                <option value="true">Yes (Advanced)</option>
-                <option value="false">No (Basic Alt/Vel only)</option>
-            </select>
-        </div>
-        <div class="control-group" id="accelGroup">
-            <label>Max Acceleration (G)</label>
-            <input type="number" id="maxAccel" value="10" min="1" max="30" step="0.5">
-        </div>
-        <div class="control-group">
-            <label>Max G-Force</label>
-            <input type="number" id="maxG" value="15" min="5" max="50" step="0.1">
+    <div class="controls-container">
+        <div class="controls">
+            <div class="control-group">
+                <label>Target Apogee (ft)</label>
+                <input type="number" id="maxAlt" value="3280" min="330" max="32800">
+            </div>
+            <div class="control-group">
+                <label>Max Velocity (ft/s)</label>
+                <input type="number" id="maxVel" value="656" min="164" max="1640">
+            </div>
+            <div class="control-group">
+                <label>Parachute System</label>
+                <select id="chuteSystem">
+                    <option value="dual">Dual Deploy (Drogue + Main)</option>
+                    <option value="single">Single Deploy (Main Only)</option>
+                </select>
+            </div>
+            <div class="control-group" id="mainDeployGroup">
+                <label>Main Deploy Altitude (ft)</label>
+                <input type="number" id="mainDeployAlt" value="800" min="100" max="2000">
+            </div>
+            <div class="control-group">
+                <label>Use Acceleration</label>
+                <select id="useAccel">
+                    <option value="true">Yes (Advanced)</option>
+                    <option value="false">No (Basic Alt/Vel only)</option>
+                </select>
+            </div>
+            <div class="control-group" id="accelGroup">
+                <label>Max Acceleration (G)</label>
+                <input type="number" id="maxAccel" value="10" min="1" max="30" step="0.5">
+            </div>
+            <div class="control-group">
+                <label>Max G-Force</label>
+                <input type="number" id="maxG" value="15" min="5" max="50" step="0.1">
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Adds a scrollbar to the target apogee controls section.

This change makes the "Use Acceleration" and "Max Acceleration" input fields accessible, which were previously out of reach due to content overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-91c11016-5168-4a5d-aa91-77310ef96803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91c11016-5168-4a5d-aa91-77310ef96803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

